### PR TITLE
Make debug toolbar conditional on DEBUG setting

### DIFF
--- a/backend/cms/settings.py
+++ b/backend/cms/settings.py
@@ -1,6 +1,6 @@
 from pathlib import Path
-import environ
 
+import environ
 
 BASE_DIR = Path(__file__).resolve().parent.parent
 
@@ -58,8 +58,9 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
-    "debug_toolbar.middleware.DebugToolbarMiddleware",
 ]
+if DEBUG:
+    MIDDLEWARE.append("debug_toolbar.middleware.DebugToolbarMiddleware")
 
 ROOT_URLCONF = "cms.urls"
 

--- a/backend/cms/urls.py
+++ b/backend/cms/urls.py
@@ -1,10 +1,12 @@
+from django.conf import settings
 from django.contrib import admin
-from django.urls import path, include
-
+from django.urls import include, path
 
 urlpatterns = [
     path("backside/", admin.site.urls),
-    path("__debug__/", include("debug_toolbar.urls")),
     path("api/", include("blog.urls")),
     path("", include("uploads.urls")),
 ]
+
+if settings.DEBUG:
+    urlpatterns.append(path("__debug__/", include("debug_toolbar.urls")))


### PR DESCRIPTION
## Summary
Only load Django debug toolbar in development environments where DEBUG=True.

## Changes
- Only add debug toolbar middleware when DEBUG=True
- Only include debug toolbar URL routes when DEBUG=True

## Problem
CI and production environments were failing because `debug_toolbar` was being imported even though the package is only installed as a dev dependency.

```
RuntimeError: Model class debug_toolbar.models.HistoryEntry doesn't declare an explicit app_label and isn't in an application in INSTALLED_APPS.
```

## Testing
- Debug toolbar still works locally with DEBUG=True
- CI/production will no longer attempt to import the module

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Conditionally enable Django debug toolbar middleware and routes only when DEBUG=True.
> 
> - **Backend (Django)**:
>   - **Settings (`backend/cms/settings.py`)**: Remove `debug_toolbar.middleware.DebugToolbarMiddleware` from default `MIDDLEWARE`; append it only when `DEBUG` is true.
>   - **URLs (`backend/cms/urls.py`)**: Register `"__debug__/"` routes only when `settings.DEBUG` is true; add `settings` import.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3b76833cab0e3023e37dec603424af59b19500a1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->