### PR TITLE
Install libatomic1 for Node.js compatibility

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Pull code from GitHub
         run: |
-          $SSH_CMD "sudo apt-get update && sudo apt-get upgrade -y && cd $REPO_DIR && git switch master && git pull"
+          $SSH_CMD "sudo apt-get update && sudo apt-get upgrade -y && sudo apt-get install -y libatomic1 && cd $REPO_DIR && git switch master && git pull"
 
       - name: Install uv
         run: |


### PR DESCRIPTION
Fixes deployment failure caused by missing `libatomic.so.1` library required by Node.js.

The error was:
```
node: error while loading shared libraries: libatomic.so.1: cannot open shared object file: No such file or directory
```

This adds `libatomic1` to the apt packages installed during deployment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `libatomic1` to the apt-get install step in `.github/workflows/deploy.yml` during EC2 deployment.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 30caff5af9a90cd89c94ea393b53c11ab60ab565. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->