### PR TITLE
Add error handling to API fetch calls

### DIFF
--- a/frontend/src/utils/getPost.ts
+++ b/frontend/src/utils/getPost.ts
@@ -2,6 +2,9 @@ import { PostInterface } from "../interfaces/PostInterface";
 
 export default async function getPost(slug: string): Promise<PostInterface> {
   const res = await fetch(`${process.env.BASE_API_URL}/posts/${slug}/`);
+  if (!res.ok) {
+    throw new Error(`API error fetching /posts/${slug}/: ${res.status} ${res.statusText}`);
+  }
   const data = await res.json();
   return data;
 }

--- a/frontend/src/utils/getPostSlugs.ts
+++ b/frontend/src/utils/getPostSlugs.ts
@@ -8,6 +8,9 @@ type PostSlug = {
 
 export async function getPostSlugs(): Promise<PostSlug[]> {
   const res = await fetch(`${process.env.BASE_API_URL}/posts/`);
+  if (!res.ok) {
+    throw new Error(`API error fetching /posts/: ${res.status} ${res.statusText}`);
+  }
   const data: PostInterface[] = await res.json();
   // Filter the data to only include the slugs
   return data.map((post) => {
@@ -25,6 +28,9 @@ export async function getPostSlugsByCategory(
   const res = await fetch(
     `${process.env.BASE_API_URL}/posts/category/${categorySlug}/`
   );
+  if (!res.ok) {
+    throw new Error(`API error fetching /posts/category/${categorySlug}/: ${res.status} ${res.statusText}`);
+  }
   const data: PostInterface[] = await res.json();
   // Filter the data to only include the slugs
   return data.map((post) => {
@@ -38,6 +44,9 @@ export async function getPostSlugsByCategory(
 
 export async function getPostCategorySlugs(): Promise<PostSlug[]> {
   const res = await fetch(`${process.env.BASE_API_URL}/categories/`);
+  if (!res.ok) {
+    throw new Error(`API error fetching /categories/: ${res.status} ${res.statusText}`);
+  }
   const data: CategoryInterface[] = await res.json();
   // Filter the data to only include the slugs
   return data.map((category) => {

--- a/frontend/src/utils/getPosts.ts
+++ b/frontend/src/utils/getPosts.ts
@@ -2,12 +2,18 @@ import { CategoryInterface, PostInterface } from "../interfaces/PostInterface";
 
 export async function getPosts(): Promise<PostInterface[]> {
   const res = await fetch(`${process.env.BASE_API_URL}/posts/`);
+  if (!res.ok) {
+    throw new Error(`API error fetching /posts/: ${res.status} ${res.statusText}`);
+  }
   const data = await res.json();
   return data;
 }
 
 export async function getLatestPosts(): Promise<PostInterface[]> {
   const res = await fetch(`${process.env.BASE_API_URL}/posts/latest/`);
+  if (!res.ok) {
+    throw new Error(`API error fetching /posts/latest/: ${res.status} ${res.statusText}`);
+  }
   const data = await res.json();
   return data;
 }
@@ -18,6 +24,9 @@ export async function getPostsByCategory(
   const res = await fetch(
     `${process.env.BASE_API_URL}/posts/category/${categorySlug}/`
   );
+  if (!res.ok) {
+    throw new Error(`API error fetching /posts/category/${categorySlug}/: ${res.status} ${res.statusText}`);
+  }
   const data = await res.json();
   return data;
 }
@@ -28,6 +37,9 @@ export async function getCategoryBySlug(
   const res = await fetch(
     `${process.env.BASE_API_URL}/categories/${categorySlug}/`
   );
+  if (!res.ok) {
+    throw new Error(`API error fetching /categories/${categorySlug}/: ${res.status} ${res.statusText}`);
+  }
   const data = await res.json();
   return data;
 }

--- a/frontend/src/utils/getTestimonials.ts
+++ b/frontend/src/utils/getTestimonials.ts
@@ -4,6 +4,9 @@ export async function getTestimonial(
   slug: string
 ): Promise<TestimonialInterface> {
   const res = await fetch(`${process.env.BASE_API_URL}/testimonials/${slug}/`);
+  if (!res.ok) {
+    throw new Error(`API error fetching /testimonials/${slug}/: ${res.status} ${res.statusText}`);
+  }
   const data = await res.json();
   return data;
 }


### PR DESCRIPTION
## Summary
- Add `res.ok` checks to all fetch utility functions before calling `.json()`
- Throw descriptive errors showing which endpoint failed and the HTTP status code
- Fixes cryptic build failures like `SyntaxError: Unexpected token '<', "<html>..."` when API returns HTML error pages

## Problem
The Next.js build was failing during static page generation with:
```
SyntaxError: Unexpected token '<', "<html>..." is not valid JSON
```

This happened because fetch calls would blindly call `.json()` without checking if the response was successful. When the API returned an error (502, 500, etc.), nginx would return an HTML error page which failed JSON parsing.

## Solution
All fetch utilities now check `res.ok` before parsing and throw descriptive errors like:
```
Error: API error fetching /posts/some-slug/: 502 Bad Gateway
```

## Test plan
- [ ] Run `npm run build` locally to verify type checking passes
- [ ] Deploy and verify build succeeds (or fails with a clear error message if API is down)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add res.ok checks and descriptive error throws across post, category, and testimonial fetch helpers.
> 
> - **Frontend Utilities**:
>   - Add `res.ok` checks and throw descriptive `Error`s before `.json()` in:
>     - `frontend/src/utils/getPost.ts`
>     - `frontend/src/utils/getPostSlugs.ts` (`getPostSlugs`, `getPostSlugsByCategory`, `getPostCategorySlugs`)
>     - `frontend/src/utils/getPosts.ts` (`getPosts`, `getLatestPosts`, `getPostsByCategory`, `getCategoryBySlug`)
>     - `frontend/src/utils/getTestimonials.ts` (`getTestimonial`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 689b842a8c0620617b75d335543f5822880e8ed8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->