### PR TITLE
Add backend health check before frontend build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -92,6 +92,10 @@ jobs:
         run: |
           $SSH_CMD "sudo systemctl restart gunicorn-${{ secrets.EC2_HOST }} || sudo systemctl start gunicorn-${{ secrets.EC2_HOST }}"
 
+      - name: Wait for backend API to be healthy
+        run: |
+          $SSH_CMD "for i in {1..30}; do curl -sf http://localhost:8000/api/posts/ > /dev/null && echo 'Backend is healthy' && exit 0; echo \"Waiting for backend... attempt \$i\"; sleep 2; done; echo 'Backend health check failed'; exit 1"
+
       - name: Copy frontend into data directory and change owner
         run: |
           $SSH_CMD "sudo cp -R $NEXTJS_BASE_DIR $DATA_DIR && sudo chown -R ${{ secrets.EC2_HOST }}:${{ secrets.EC2_HOST }} $DATA_DIR"


### PR DESCRIPTION
## Summary
- Add a health check step after restarting gunicorn and before the frontend build
- Waits for the backend API (`/api/posts/`) to respond with 200 OK
- Retries up to 30 times with 2-second delays (60 seconds total)

## Problem
The deploy was failing with `502 Bad Gateway` during the Next.js build because the backend wasn't ready yet after being restarted:
```
Error: API error fetching /posts/: 502 Bad Gateway
```

## Solution
Add a wait step that polls the backend API until it's healthy before starting the frontend build.

## Test plan
- [ ] Merge and observe next deploy - should see "Backend is healthy" message before frontend build starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add a health check step in the deploy workflow to wait for the backend API after gunicorn restarts before building the frontend.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 35dd723bc1a25bc8362b8a3f85fc770c6ec6d260. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->