### PR TITLE
Fix uv Python install location for service user access

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,6 +24,7 @@ jobs:
       STATICFILES_DIR: /var/opt/${{ secrets.EC2_HOST }}/staticfiles
       NEXTJS_BASE_DIR: /opt/${{ secrets.EC2_HOST }}/frontend
       NEXTJS_BUILD_DIR: /var/opt/${{ secrets.EC2_HOST }}/frontend
+      UV_PYTHON_DIR: /opt/uv/python
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -74,7 +75,7 @@ jobs:
 
       - name: Install Python dependencies
         run: |
-          $SSH_CMD "cd $DJANGO_BASE_DIR && sudo uv sync --frozen"
+          $SSH_CMD "sudo mkdir -p $UV_PYTHON_DIR && cd $DJANGO_BASE_DIR && sudo UV_PYTHON_INSTALL_DIR=$UV_PYTHON_DIR uv sync --frozen && sudo chmod -R a+rx /opt/uv"
 
       - name: Python manage.py migrate
         run: |


### PR DESCRIPTION
## Summary
- Configure uv to install Python in `/opt/uv/python` instead of `/root/.local/share/uv/`
- Set world-readable permissions on the uv directory

## Problem
The gunicorn service was failing with "Permission denied" because:
1. `sudo uv sync` installs Python to `/root/.local/share/uv/python/`
2. The service runs as user `johndusel.com` who cannot access root's home directory
3. The venv's Python symlink pointed to an inaccessible location

## Root Cause
```
/opt/johndusel.com/backend/.venv/bin/python -> /root/.local/share/uv/python/cpython-3.11.4-linux-x86_64-gnu/bin/python3.11
```

This symlink was broken for non-root users.

## Solution
Set `UV_PYTHON_INSTALL_DIR=/opt/uv/python` when running uv sync, so Python is installed in a shared location accessible by all users.

## Test plan
- [x] Manually fixed on server and verified gunicorn starts
- [ ] Next deploy should work without manual intervention

🤖 Generated with [Claude Code](https://claude.com/claude-code)