### PR TITLE
Serve johndusel.com as a static site (build-time CMS)

### DIFF
--- a/docs/STATIC_DEPLOY.md
+++ b/docs/STATIC_DEPLOY.md
@@ -1,0 +1,61 @@
+# Static deployment
+
+johndusel.com is served as a **fully static site**. The client's content is
+frozen (he's no longer composing posts), so the Django CMS is only needed at
+**build time** as a content source. Next.js fetches the content via
+`getStaticProps`/`getStaticPaths` and bakes it into HTML; the deployed result is
+plain files behind Caddy's `file_server` — no Django, no DB, no containers at
+runtime.
+
+## What still has to exist
+
+- **S3 bucket `johndusel.com`** (us-east-2): post-body images are absolute URLs
+  like `https://s3.us-east-2.amazonaws.com/johndusel.com/production/images/...`,
+  baked into the content. As long as the bucket stays public, images just work.
+  Nothing else in AWS is needed.
+- **A DB backup** to build from. Production SQLite backups live on the flexion
+  NAS: `/mnt/{mirror1,storage}/Websites/johndusel.com/backups/db/johndusel_db_*.backup.sqlite3`.
+- The **MailerLite** newsletter form (in `Hero.tsx`) posts directly to MailerLite
+  — external, works fine on a static site.
+
+## How it's wired for static
+
+- `frontend/next.config.js`: `output: "export"` + `images: { unoptimized: true }`.
+- `getStaticPaths` uses `fallback: false` (all pages known at build time).
+- No `pages/api`, no `getServerSideProps` — nothing requires a runtime server.
+
+## Build it (on any machine)
+
+Prereqs: `uv` (backend), `node`/`npm` (frontend).
+
+```bash
+# 1. Grab a DB backup (once), e.g. from the flexion NAS:
+scp flexion:/mnt/mirror1/Websites/johndusel.com/backups/db/johndusel_db_20260317.backup.sqlite3 /tmp/jd.sqlite3
+
+# 2. Build the static site (starts a build-time backend, exports, stops it):
+just build-static /tmp/jd.sqlite3      # or: scripts/build-static.sh /tmp/jd.sqlite3
+
+# 3. Preview locally:
+just preview-static                    # http://localhost:8081
+```
+
+Output is `frontend/out/`.
+
+## Deploy to Hetzner
+
+The site is served by the shared Caddy on the Hetzner box via the `deploy`
+tooling's static-site flow (`PROJECT_TYPE=static`, atomic `releases/` + `current`
+symlink). Ship `frontend/out/` as a new release, then point DNS:
+
+- Caddy site block reverse-serves the release dir with `try_files {path} {path}.html {path}/ /404.html`
+  (Next export emits extensionless routes as `<route>.html`).
+- **DNS:** `johndusel.com` is on **Namecheap** — point the apex (and `www`) at the
+  Hetzner IP `178.156.203.110`. Caddy fetches TLS automatically once DNS resolves.
+
+## Editing content later
+
+Content is frozen, but if the client ever needs a change:
+
+1. Bring the backend up locally with the latest DB, edit via Django admin.
+2. Re-run `just build-static` and redeploy `frontend/out/`.
+3. The Django backend never has to be publicly hosted again.

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -4,7 +4,10 @@ const { withSentryConfig } = require("@sentry/nextjs");
 const nextConfig = {
   reactStrictMode: true,
   staticPageGenerationTimeout: 1000,
-  output: "standalone",
+  // Static HTML export — the Django CMS is only needed at build time.
+  output: "export",
+  // Required for `output: export` (no Next.js image-optimization server at runtime).
+  images: { unoptimized: true },
   env: {
     SITE_TITLE: "John Dusel",
     SITE_DESCRIPTION:

--- a/frontend/src/pages/[slug].tsx
+++ b/frontend/src/pages/[slug].tsx
@@ -32,8 +32,8 @@ export const getStaticPaths: GetStaticPaths = async () => {
   const paths = await getPostSlugs();
   return {
     paths,
-    // Use 'blocking' to generate pages on-demand if not built at build time
-    fallback: "blocking",
+    // Static export: all pages are generated at build time (content is frozen).
+    fallback: false,
   };
 };
 

--- a/frontend/src/pages/category/[slug].tsx
+++ b/frontend/src/pages/category/[slug].tsx
@@ -55,8 +55,8 @@ export const getStaticPaths: GetStaticPaths = async () => {
   const paths = await getPostCategorySlugs();
   return {
     paths,
-    // Use 'blocking' to generate pages on-demand if not built at build time
-    fallback: "blocking",
+    // Static export: all pages are generated at build time (content is frozen).
+    fallback: false,
   };
 };
 

--- a/justfile
+++ b/justfile
@@ -74,6 +74,18 @@ npm-install:
     cd frontend && npm install
 
 # ─────────────────────────────────────────────────────────────────────────────
+# Static deployment (see docs/STATIC_DEPLOY.md)
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Build the fully static site into frontend/out/ (pass a DB backup path the first time)
+build-static db="":
+    bash scripts/build-static.sh {{db}}
+
+# Preview the built static site locally at http://localhost:8081
+preview-static:
+    cd frontend/out && python3 -m http.server 8081
+
+# ─────────────────────────────────────────────────────────────────────────────
 # Full Stack
 # ─────────────────────────────────────────────────────────────────────────────
 

--- a/scripts/build-static.sh
+++ b/scripts/build-static.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Build johndusel.com as a fully static site into frontend/out/.
+#
+# The Django backend is only a BUILD-TIME content source: Next.js fetches the
+# (frozen) CMS content via getStaticProps, bakes it into HTML, and the result
+# needs no backend at runtime. Post images are absolute S3 URLs, so the only
+# external runtime dependency is the `johndusel.com` S3 bucket.
+#
+# Usage:
+#   scripts/build-static.sh [path/to/db-backup.sqlite3]
+#
+# Pass a SQLite backup the first time (e.g. the dated backup from the flexion
+# NAS at /mnt/mirror1/Websites/johndusel.com/backups/db/). Subsequent runs reuse
+# backend/db.sqlite3 if no path is given.
+#
+# Prereqs: uv (backend), node + npm (frontend).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DB_SRC="${1:-}"
+PORT="${BACKEND_PORT:-8000}"
+SITE_URL="${SITE_URL:-https://johndusel.com}"
+
+cd "$ROOT/backend"
+if [[ -n "$DB_SRC" ]]; then
+  echo "→ Using DB backup: $DB_SRC"
+  cp "$DB_SRC" ./db.sqlite3
+fi
+if [[ ! -f ./db.sqlite3 ]]; then
+  echo "ERROR: backend/db.sqlite3 not found." >&2
+  echo "       Pass a backup path, e.g.:" >&2
+  echo "       scripts/build-static.sh ~/Downloads/johndusel_db_YYYYMMDD.backup.sqlite3" >&2
+  exit 1
+fi
+
+# DEBUG=True keeps it a simple local content source (no prod SSL redirects etc.).
+export DATABASE_URL="sqlite:///$(pwd)/db.sqlite3"
+export SECRET_KEY="${SECRET_KEY:-build-time-only-not-secret}"
+export DEBUG=True
+export ALLOWED_HOSTS="localhost,127.0.0.1"
+export ENVIRONMENT=development
+
+echo "→ Applying migrations (no-op if DB is current)..."
+uv run python manage.py migrate --noinput
+
+echo "→ Starting build-time backend on 127.0.0.1:${PORT}..."
+uv run python manage.py runserver "127.0.0.1:${PORT}" >/tmp/jd-build-backend.log 2>&1 &
+BACKEND_PID=$!
+trap 'kill "${BACKEND_PID}" 2>/dev/null || true' EXIT
+
+# Wait for the API (curl handles the retry/backoff; no sleep needed).
+if ! curl -s --retry 30 --retry-delay 1 --retry-connrefused -o /dev/null \
+        "http://127.0.0.1:${PORT}/api/posts/"; then
+  echo "ERROR: build-time backend never answered on :${PORT}. See /tmp/jd-build-backend.log" >&2
+  exit 1
+fi
+echo "  backend is serving content."
+
+cd "$ROOT/frontend"
+echo "→ Installing frontend deps..."
+npm ci 2>/dev/null || npm install
+echo "→ Building static export..."
+BASE_API_URL="http://127.0.0.1:${PORT}/api" SITE_URL="${SITE_URL}" SENTRY_DRY_RUN=true npm run build
+
+echo
+echo "✅ Static site built at frontend/out/"
+echo "   Preview:  cd frontend/out && python3 -m http.server 8081"
+echo "   Deploy:   ship frontend/out/ to Hetzner (Caddy file_server) — see docs/STATIC_DEPLOY.md"


### PR DESCRIPTION
## Why

The client (John Dusel) is no longer paying to keep the site running and isn't composing new content. Since the content is frozen, the Django CMS only needs to exist **at build time** — so we can serve johndusel.com as a **fully static site** (Caddy `file_server`): near-zero cost, no backend/DB/containers at runtime, minimal attack surface.

## What this does

- **`next.config.js`** → `output: "export"` + `images: { unoptimized: true }`.
- **`getStaticPaths` `fallback: "blocking"` → `false`** in `[slug].tsx` and `category/[slug].tsx` (all pages are known at build time; required for export).
- **`scripts/build-static.sh`** — one-shot reproducible build: restore a DB backup → start a build-time Django backend → `next build` (static export) → stop the backend. Output is `frontend/out/`.
- **`justfile`** — `build-static` / `preview-static` recipes.
- **`docs/STATIC_DEPLOY.md`** — end-to-end: prereqs, where the DB backups live (flexion NAS), the S3 image dependency, build, deploy to Hetzner, and DNS (Namecheap).

## Verified locally

- Builds **8 static pages** (home, both posts, 3 categories, `/posts`, `/about`).
- Site **serves correctly with the backend stopped**.
- Post-body images load from the existing **`johndusel.com` S3 bucket** (absolute URLs baked into content — confirmed `HTTP 200`).
- Newsletter form posts to **MailerLite** (external) — no backend needed.
- `scripts/build-static.sh` runs clean end-to-end and auto-stops the backend.

## Runtime dependencies (intentional)

- The **S3 bucket `johndusel.com`** must stay public (serves the post images).
- Nothing else — no EC2, no live Django.

## Notes

- Base is `dockerize-deployment` (this builds on that branch's uv/justfile foundation).
- `db.sqlite3` and `frontend/out/` stay gitignored.
- Deploy + DNS cutover (Namecheap → Hetzner) are the next step, tracked separately.
